### PR TITLE
UEFI support

### DIFF
--- a/gameros/packages.x86_64
+++ b/gameros/packages.x86_64
@@ -3,3 +3,4 @@ parted
 libnewt
 syslinux
 openssh
+efibootmgr

--- a/gameros/packages.x86_64
+++ b/gameros/packages.x86_64
@@ -4,3 +4,4 @@ libnewt
 syslinux
 openssh
 efibootmgr
+dosfstools


### PR DESCRIPTION
This adds the packages efibootmgr and dosfstools to the ISO. Without them creating the boot partition and adding an entry to the UEFI of the user wouldn't be possible.