### PR TITLE
add valveaur

### DIFF
--- a/gameros/pacman.conf
+++ b/gameros/pacman.conf
@@ -94,6 +94,9 @@ Include = /etc/pacman.d/mirrorlist
 #[multilib]
 #Include = /etc/pacman.d/mirrorlist
 
+[valveaur]
+Server = http://repo.steampowered.com/arch/valveaur
+
 # An example of a custom package repository.  See the pacman manpage for
 # tips on creating your own repositories.
 #[custom]


### PR DESCRIPTION
[https://wiki.archlinux.org/index.php/Unofficial_user_repositories#valveaur](url)
**Description:** A repository by Valve Software Providing The Linux-fsync kernel and modules, including the futex-wait-multiple patchset for testing with Proton fsync & Mesa with the ACO compiler patchset.