### PR TITLE
Fixed the default entry in UEFI bootloader

### DIFF
--- a/gameros/efiboot/loader/loader.conf
+++ b/gameros/efiboot/loader/loader.conf
@@ -1,2 +1,2 @@
 timeout 30
-default archiso-x86_64
+default archiso-x86_64.conf


### PR DESCRIPTION
The default entry needs to be the full entry file name.

https://wiki.archlinux.org/index.php/systemd-boot#Loader_configuration