### PR TITLE
V1 for wireless installation

### DIFF
--- a/gameros/packages.x86_64
+++ b/gameros/packages.x86_64
@@ -15,3 +15,5 @@ usbutils
 mkinitcpio
 linux
 mkinitcpio-archiso
+wpa_supplicant
+iwd


### PR DESCRIPTION
I managed to install gamer-os using wireless network by adding these two packages, building the image and then using `iwctl` to connect to a network before running the install script.

I know this is not ideal, and it's a bit hacky, but at least it works :). I'm happy to write some docs in the other repo if you want.